### PR TITLE
顧客登録と顧客マスタ管理の更新部分の修正

### DIFF
--- a/PatisserieCestBon/Controllers/CustomerController.cs
+++ b/PatisserieCestBon/Controllers/CustomerController.cs
@@ -152,7 +152,7 @@ namespace PatisserieCestBon.Controllers
             //入力項目に不備があった際に入力画面に遷移させる処理
             if (compNameCheck == 1 || addressCheck == 1 || telNoCheck == 1 || customerNameCheck == 1 ||
            customerKanaCheck == 1 || passwordCheck == 1 || retypePasswordCheck == 1 || matchPasswordCheck == 1 ||
-           formatTelNoCheck == 1 || formatEmailCheck == 1 || typeEmailCheck == 1 || typeTelCheck == 1)
+           formatTelNoCheck == 1 || formatKanaCheck == 1 || formatEmailCheck == 1 || typeEmailCheck == 1 || typeTelCheck == 1)
             {
                 return View("CustomerAdd1");
             }
@@ -387,7 +387,7 @@ namespace PatisserieCestBon.Controllers
             //入力項目に不備があった際に入力画面に遷移させる処理
             if (compNameCheck == 1 || addressCheck == 1 || telNoCheck == 1 || customerNameCheck == 1 ||
                customerKanaCheck == 1 || passwordCheck == 1 || retypePasswordCheck == 1 || matchPasswordCheck == 1 ||
-               formatTelNoCheck == 1 || formatEmailCheck == 1 || typeEmailCheck == 1 || typeTelCheck == 1)
+               formatTelNoCheck == 1 || formatKanaCheck == 1 || formatEmailCheck == 1 || typeEmailCheck == 1 || typeTelCheck == 1)
             {
                 return View("Update1");
             }

--- a/PatisserieCestBon/Views/Customer/Update2.cshtml
+++ b/PatisserieCestBon/Views/Customer/Update2.cshtml
@@ -36,7 +36,7 @@
                 <th style="text-align:center">電話番号</th>
                 <th>@ViewBag.telNo</th>
             </tr>
-            <tr><th colspan="2" style="text-align:center">ご担当者様情報</th></tr>
+            <tr><th colspan="2" style="text-align:center">顧客担当者情報</th></tr>
             <tr>
                 <th style="text-align:center">氏名(漢字)</th>
                 <th>@ViewBag.customerName</th>
@@ -65,7 +65,7 @@
             <input type="hidden" name="dept" value="@ViewBag.dept">
             <input type="hidden" name="email" value="@ViewBag.email">
             <input type="hidden" name="password" value="@ViewBag.password"><br />
-            <input type="submit" value="登録" />
+            <input type="submit" value="更新" />
             <input type="button" onclick="history.back()" value="戻る" />
         </form>
     </div>


### PR DESCRIPTION
顧客登録と顧客マスタ管理の更新の入力欄で氏名(かな)がカタカナで入力しても通ってしまうバグを修正しました
顧客マスタ管理の更新確認画面の変更点
・ボタンの名前を「登録」から「更新」に
・「ご担当者様情報」を「顧客担当者情報」に